### PR TITLE
feat(ui): landing page + theme picker form

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KidsTune</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&family=Quicksand:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,13 +7,14 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests yet\" && exit 0"
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^15.4.0",
-    "i18next": "^24.2.0"
+    "i18next": "^24.2.0",
+    "react-router-dom": "^7.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",
@@ -23,6 +24,10 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^3.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.6.0",
+    "jsdom": "^25.0.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,18 @@
-import { useTranslation } from "react-i18next";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import LandingPage from "./pages/LandingPage";
+import CreatePage from "./pages/CreatePage";
+import LanguageFooter from "./components/LanguageFooter";
 
-function App() {
-  const { t } = useTranslation();
-
+export default function App() {
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gradient-to-b from-sky-100 to-purple-100">
-      <div className="text-center">
-        <h1 className="text-5xl font-bold text-purple-600">
-          {t("app.title")}
-        </h1>
-        <p className="mt-4 text-lg text-gray-600">Coming soon</p>
+    <BrowserRouter>
+      <div className="min-h-screen bg-background flex flex-col">
+        <Routes>
+          <Route path="/" element={<LandingPage />} />
+          <Route path="/criar" element={<CreatePage />} />
+        </Routes>
+        <LanguageFooter />
       </div>
-    </main>
+    </BrowserRouter>
   );
 }
-
-export default App;

--- a/frontend/src/__tests__/CreatePage.test.tsx
+++ b/frontend/src/__tests__/CreatePage.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import { I18nextProvider } from "react-i18next";
+import i18n from "../i18n";
+import CreatePage from "../pages/CreatePage";
+
+function renderWithProviders() {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>
+        <CreatePage />
+      </BrowserRouter>
+    </I18nextProvider>,
+  );
+}
+
+describe("CreatePage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the form title", () => {
+    renderWithProviders();
+    const title = screen.getByRole("heading", { level: 1 });
+    expect(title).toBeInTheDocument();
+    expect(title.textContent).toBeTruthy();
+  });
+
+  it("renders all form fields (theme select, kid name, voice, style)", () => {
+    renderWithProviders();
+
+    // Theme select
+    expect(screen.getByLabelText(/theme|tema/i)).toBeInTheDocument();
+
+    // Kid name input
+    expect(screen.getByLabelText(/kid's name|nome da criança/i)).toBeInTheDocument();
+
+    // Voice select
+    expect(screen.getByLabelText(/voice|voz/i)).toBeInTheDocument();
+
+    // Style select
+    expect(screen.getByLabelText(/style|estilo/i)).toBeInTheDocument();
+  });
+
+  it("renders the submit button", () => {
+    renderWithProviders();
+    const submitBtn = screen.getByRole("button", { name: /generate song|gerar música/i });
+    expect(submitBtn).toBeInTheDocument();
+  });
+
+  it("shows custom keyword input when theme is Custom", () => {
+    renderWithProviders();
+
+    const themeSelect = screen.getByLabelText(/theme|tema/i);
+    fireEvent.change(themeSelect, { target: { value: "custom" } });
+
+    expect(screen.getByLabelText(/custom keyword|palavra-chave personalizada/i)).toBeInTheDocument();
+  });
+
+  it("disables submit button while submitting", async () => {
+    // Mock fetch to never resolve during this test
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      () => new Promise(() => {}),
+    );
+
+    renderWithProviders();
+
+    const submitBtn = screen.getByRole("button", { name: /generate song|gerar música/i });
+    fireEvent.click(submitBtn);
+
+    // After clicking, button should be disabled and show loading
+    await waitFor(() => {
+      expect(submitBtn).toBeDisabled();
+    });
+  });
+
+  it("shows friendly message when backend returns 404", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    renderWithProviders();
+
+    const submitBtn = screen.getByRole("button", { name: /generate song|gerar música/i });
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/coming soon|volte em breve/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/LandingPage.test.tsx
+++ b/frontend/src/__tests__/LandingPage.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import { I18nextProvider } from "react-i18next";
+import i18n from "../i18n";
+import LandingPage from "../pages/LandingPage";
+
+function renderWithProviders() {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>
+        <LandingPage />
+      </BrowserRouter>
+    </I18nextProvider>,
+  );
+}
+
+describe("LandingPage", () => {
+  it("renders the landing title from i18n", () => {
+    renderWithProviders();
+    const title = screen.getByRole("heading", { level: 1 });
+    expect(title).toBeInTheDocument();
+    expect(title.textContent).toBeTruthy();
+  });
+
+  it("renders the CTA button with correct text", () => {
+    renderWithProviders();
+    const cta = screen.getByRole("button", { name: /create a song|criar uma música/i });
+    expect(cta).toBeInTheDocument();
+  });
+
+  it("renders theme preview cards", () => {
+    renderWithProviders();
+    // Theme cards have emoji characters
+    expect(screen.getByText("🐾")).toBeInTheDocument();
+    expect(screen.getByText("✨")).toBeInTheDocument();
+    expect(screen.getByText("🎂")).toBeInTheDocument();
+  });
+
+  it("has a link/button that navigates to /criar", () => {
+    renderWithProviders();
+    const cta = screen.getByRole("button", { name: /create a song|criar uma música/i });
+    // In our setup the button uses navigate(), so it's not a regular link
+    // We just verify it exists and is clickable
+    expect(cta).toBeEnabled();
+  });
+});

--- a/frontend/src/__tests__/i18n.test.tsx
+++ b/frontend/src/__tests__/i18n.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { BrowserRouter } from "react-router-dom";
+import { I18nextProvider } from "react-i18next";
+import i18n from "../i18n";
+import LandingPage from "../pages/LandingPage";
+import LanguageFooter from "../components/LanguageFooter";
+
+function renderApp() {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>
+        <LandingPage />
+        <LanguageFooter />
+      </BrowserRouter>
+    </I18nextProvider>,
+  );
+}
+
+describe("i18n language switching", () => {
+  it("renders English by default", () => {
+    i18n.changeLanguage("en-US");
+    renderApp();
+
+    // The CTA should be in English
+    const cta = screen.getByRole("button", { name: /create a song/i });
+    expect(cta).toBeInTheDocument();
+  });
+
+  it("switches to Portuguese when PT-BR is clicked", () => {
+    i18n.changeLanguage("en-US");
+    renderApp();
+
+    // Click PT-BR button
+    const ptBrBtn = screen.getByRole("button", { name: /pt-br/i });
+    fireEvent.click(ptBrBtn);
+
+    // After switching, the CTA should be in Portuguese
+    const cta = screen.getByRole("button", { name: /criar uma música/i });
+    expect(cta).toBeInTheDocument();
+  });
+
+  it("switches back to English when EN-US is clicked", () => {
+    i18n.changeLanguage("pt-BR");
+    renderApp();
+
+    // Click EN-US button
+    const enUsBtn = screen.getByRole("button", { name: /en-us/i });
+    fireEvent.click(enUsBtn);
+
+    // After switching back, the CTA should be in English
+    const cta = screen.getByRole("button", { name: /create a song/i });
+    expect(cta).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,0 +1,38 @@
+import { type ButtonHTMLAttributes } from "react";
+
+type ButtonVariant = "primary" | "secondary";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "bg-primary text-white hover:opacity-90 active:opacity-80 shadow-md",
+  secondary:
+    "bg-secondary text-gray-800 hover:opacity-90 active:opacity-80",
+};
+
+export default function Button({
+  variant = "primary",
+  className = "",
+  children,
+  disabled,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      className={`
+        font-body font-semibold text-body px-6 py-3 rounded-[0.75rem]
+        transition-all duration-200 ease-in-out
+        disabled:opacity-50 disabled:cursor-not-allowed
+        ${variantClasses[variant]}
+        ${className}
+      `.trim()}
+      disabled={disabled}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/LanguageFooter.tsx
+++ b/frontend/src/components/LanguageFooter.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "react-i18next";
+
+export default function LanguageFooter() {
+  const { t, i18n } = useTranslation();
+
+  function handleLanguageChange(lng: string) {
+    i18n.changeLanguage(lng);
+  }
+
+  return (
+    <footer className="bg-background border-t border-gray-200 py-4 px-4">
+      <div className="max-w-3xl mx-auto flex items-center justify-center gap-3">
+        <span className="font-body text-small text-gray-500">
+          {t("common.language")}:
+        </span>
+        <button
+          className={`font-body text-small px-3 py-1 rounded transition-colors ${
+            i18n.language === "en-US"
+              ? "bg-primary text-white"
+              : "text-gray-600 hover:text-primary"
+          }`}
+          onClick={() => handleLanguageChange("en-US")}
+        >
+          EN-US
+        </button>
+        <button
+          className={`font-body text-small px-3 py-1 rounded transition-colors ${
+            i18n.language === "pt-BR"
+              ? "bg-primary text-white"
+              : "text-gray-600 hover:text-primary"
+          }`}
+          onClick={() => handleLanguageChange("pt-BR")}
+        >
+          PT-BR
+        </button>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -1,0 +1,56 @@
+import { type SelectHTMLAttributes } from "react";
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps extends SelectHTMLAttributes<HTMLSelectElement> {
+  label: string;
+  options: SelectOption[];
+  placeholder?: string;
+}
+
+export default function Select({
+  label,
+  options,
+  placeholder,
+  className = "",
+  id,
+  ...rest
+}: SelectProps) {
+  const selectId = id ?? `select-${label.toLowerCase().replace(/\s+/g, "-")}`;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={selectId}
+        className="font-body font-semibold text-small text-gray-700"
+      >
+        {label}
+      </label>
+      <select
+        id={selectId}
+        className={`
+          font-body text-body px-4 py-3 rounded-input border-2 border-gray-200
+          bg-white text-gray-800
+          focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20
+          transition-all duration-150
+          ${className}
+        `.trim()}
+        {...rest}
+      >
+        {placeholder && (
+          <option value="" disabled>
+            {placeholder}
+          </option>
+        )}
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/ThemeCard.tsx
+++ b/frontend/src/components/ThemeCard.tsx
@@ -1,0 +1,21 @@
+interface ThemeCardProps {
+  emoji: string;
+  label: string;
+  color: string;
+}
+
+export default function ThemeCard({ emoji, label, color }: ThemeCardProps) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 p-6 rounded-card shadow-sm transition-transform duration-200 hover:scale-105 hover:shadow-md"
+      style={{ backgroundColor: color }}
+    >
+      <span className="text-4xl" aria-hidden="true">
+        {emoji}
+      </span>
+      <span className="font-display font-semibold text-h3 text-gray-800">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1,5 +1,63 @@
 {
   "app": {
     "title": "KidsTune"
+  },
+  "landing": {
+    "title": "A song made just for your child",
+    "subtitle": "Every melody is unique — your kid's name appears in the lyrics, making every listen extra special.",
+    "cta": "Create a song",
+    "theme": {
+      "animals": "Animals 🐾",
+      "fantasy": "Fantasy ✨",
+      "birthday": "Birthday 🎂"
+    }
+  },
+  "criar": {
+    "title": "Create your song",
+    "form": {
+      "theme": {
+        "label": "Theme",
+        "placeholder": "Choose a theme"
+      },
+      "kidName": {
+        "label": "Kid's name (optional)",
+        "placeholder": "Ex: Lara"
+      },
+      "voice": {
+        "label": "Voice",
+        "placeholder": "Choose a voice"
+      },
+      "style": {
+        "label": "Style",
+        "placeholder": "Choose a style"
+      }
+    },
+    "submit": "Generate song",
+    "generating": "We're creating a song full of love for {{name}}...",
+    "comingSoon": "This feature is coming soon! Check back shortly.",
+    "customKeyword": "Custom keyword"
+  },
+  "common": {
+    "loading": "Loading...",
+    "error": "Something went wrong. Please try again.",
+    "language": "Language"
+  },
+  "voice": {
+    "feminine": "Feminine",
+    "masculine": "Masculine",
+    "instrumental": "Instrumental"
+  },
+  "style": {
+    "lullaby": "Lullaby",
+    "pop": "Pop",
+    "folk": "Folk"
+  },
+  "themeOption": {
+    "animals": "Animals",
+    "fantasy": "Fantasy",
+    "butterflies": "Butterflies",
+    "adventure": "Adventure",
+    "bedtime": "Bedtime",
+    "custom": "Custom"
   }
 }

--- a/frontend/src/locales/pt-BR.json
+++ b/frontend/src/locales/pt-BR.json
@@ -1,5 +1,63 @@
 {
   "app": {
     "title": "KidsTune"
+  },
+  "landing": {
+    "title": "Uma música feita para o seu filho",
+    "subtitle": "Cada melodia é única — o nome do seu filho aparece na letra, tornando cada audição ainda mais especial.",
+    "cta": "Criar uma música",
+    "theme": {
+      "animals": "Animais 🐾",
+      "fantasy": "Fantasia ✨",
+      "birthday": "Aniversário 🎂"
+    }
+  },
+  "criar": {
+    "title": "Crie sua música",
+    "form": {
+      "theme": {
+        "label": "Tema",
+        "placeholder": "Escolha um tema"
+      },
+      "kidName": {
+        "label": "Nome da criança (opcional)",
+        "placeholder": "Ex: Lara"
+      },
+      "voice": {
+        "label": "Voz",
+        "placeholder": "Escolha uma voz"
+      },
+      "style": {
+        "label": "Estilo",
+        "placeholder": "Escolha um estilo"
+      }
+    },
+    "submit": "Gerar música",
+    "generating": "Estamos criando uma música cheia de carinho para {{name}}...",
+    "comingSoon": "Esta funcionalidade estará disponível em breve! Volte em breve.",
+    "customKeyword": "Palavra-chave personalizada"
+  },
+  "common": {
+    "loading": "Carregando...",
+    "error": "Algo deu errado. Tente novamente.",
+    "language": "Idioma"
+  },
+  "voice": {
+    "feminine": "Feminina",
+    "masculine": "Masculina",
+    "instrumental": "Instrumental"
+  },
+  "style": {
+    "lullaby": "Ninar",
+    "pop": "Pop",
+    "folk": "Folk"
+  },
+  "themeOption": {
+    "animals": "Animais",
+    "fantasy": "Fantasia",
+    "butterflies": "Borboletas",
+    "adventure": "Aventura",
+    "bedtime": "Hora de dormir",
+    "custom": "Personalizado"
   }
 }

--- a/frontend/src/pages/CreatePage.tsx
+++ b/frontend/src/pages/CreatePage.tsx
@@ -1,0 +1,192 @@
+import { useState, type FormEvent } from "react";
+import { useTranslation } from "react-i18next";
+import Button from "../components/Button";
+import Select from "../components/Select";
+
+interface FormData {
+  theme: string;
+  customKeyword: string;
+  kidName: string;
+  voice: string;
+  style: string;
+}
+
+export default function CreatePage() {
+  const { t } = useTranslation();
+  const [form, setForm] = useState<FormData>({
+    theme: "",
+    customKeyword: "",
+    kidName: "",
+    voice: "",
+    style: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const themeOptions = [
+    { value: "animals", label: t("themeOption.animals") },
+    { value: "fantasy", label: t("themeOption.fantasy") },
+    { value: "butterflies", label: t("themeOption.butterflies") },
+    { value: "adventure", label: t("themeOption.adventure") },
+    { value: "bedtime", label: t("themeOption.bedtime") },
+    { value: "custom", label: t("themeOption.custom") },
+  ];
+
+  const voiceOptions = [
+    { value: "feminine", label: t("voice.feminine") },
+    { value: "masculine", label: t("voice.masculine") },
+    { value: "instrumental", label: t("voice.instrumental") },
+  ];
+
+  const styleOptions = [
+    { value: "lullaby", label: t("style.lullaby") },
+    { value: "pop", label: t("style.pop") },
+    { value: "folk", label: t("style.folk") },
+  ];
+
+  function handleChange(
+    field: keyof FormData,
+    value: string,
+  ) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setMessage(null);
+
+    const payload = {
+      theme: form.theme === "custom" ? form.customKeyword : form.theme,
+      kidName: form.kidName,
+      voice: form.voice,
+      style: form.style,
+    };
+
+    try {
+      const res = await fetch("/api/generate", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        // Backend route not available yet (Epic 4)
+        setMessage(t("criar.comingSoon"));
+      }
+    } catch {
+      // fetch throws on network error — also show friendly message
+      setMessage(t("criar.comingSoon"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const isCustom = form.theme === "custom";
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center px-4 py-12">
+      <div className="w-full max-w-lg">
+        <h1 className="font-display font-bold text-h1 text-primary text-center mb-8">
+          {t("criar.title")}
+        </h1>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-5 bg-white p-6 sm:p-8 rounded-card shadow-sm"
+        >
+          {/* Theme dropdown */}
+          <Select
+            label={t("criar.form.theme.label")}
+            placeholder={t("criar.form.theme.placeholder")}
+            options={themeOptions}
+            value={form.theme}
+            onChange={(e) => handleChange("theme", e.target.value)}
+          />
+
+          {/* Custom keyword input — only when 'custom' is selected */}
+          {isCustom && (
+            <div className="flex flex-col gap-1.5">
+              <label
+                htmlFor="custom-keyword"
+                className="font-body font-semibold text-small text-gray-700"
+              >
+                {t("criar.customKeyword")}
+              </label>
+              <input
+                id="custom-keyword"
+                type="text"
+                className="font-body text-body px-4 py-3 rounded-input border-2 border-gray-200 bg-white text-gray-800 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-all duration-150"
+                value={form.customKeyword}
+                onChange={(e) =>
+                  handleChange("customKeyword", e.target.value)
+                }
+                placeholder="Ex: Dinossauros"
+              />
+            </div>
+          )}
+
+          {/* Kid name input */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="kid-name"
+              className="font-body font-semibold text-small text-gray-700"
+            >
+              {t("criar.form.kidName.label")}
+            </label>
+            <input
+              id="kid-name"
+              type="text"
+              className="font-body text-body px-4 py-3 rounded-input border-2 border-gray-200 bg-white text-gray-800 focus:outline-none focus:border-primary focus:ring-2 focus:ring-primary/20 transition-all duration-150"
+              value={form.kidName}
+              onChange={(e) => handleChange("kidName", e.target.value)}
+              placeholder={t("criar.form.kidName.placeholder")}
+            />
+          </div>
+
+          {/* Voice dropdown */}
+          <Select
+            label={t("criar.form.voice.label")}
+            placeholder={t("criar.form.voice.placeholder")}
+            options={voiceOptions}
+            value={form.voice}
+            onChange={(e) => handleChange("voice", e.target.value)}
+          />
+
+          {/* Style dropdown */}
+          <Select
+            label={t("criar.form.style.label")}
+            placeholder={t("criar.form.style.placeholder")}
+            options={styleOptions}
+            value={form.style}
+            onChange={(e) => handleChange("style", e.target.value)}
+          />
+
+          {/* Submit button */}
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={submitting}
+            className="w-full"
+          >
+            {submitting ? t("common.loading") : t("criar.submit")}
+          </Button>
+        </form>
+
+        {/* Status message */}
+        {submitting && (
+          <p className="font-body text-body text-primary text-center mt-6 animate-pulse">
+            {t("criar.generating", {
+              name: form.kidName || t("criar.title"),
+            })}
+          </p>
+        )}
+
+        {message && (
+          <p className="font-body text-body text-gray-600 text-center mt-6 bg-secondary/30 p-4 rounded-card">
+            {message}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router-dom";
+import Button from "../components/Button";
+import ThemeCard from "../components/ThemeCard";
+
+const themes = [
+  {
+    emoji: "🐾",
+    labelKey: "landing.theme.animals",
+    color: "#FAB1A0",
+  },
+  {
+    emoji: "✨",
+    labelKey: "landing.theme.fantasy",
+    color: "#6C5CE7",
+  },
+  {
+    emoji: "🎂",
+    labelKey: "landing.theme.birthday",
+    color: "#FFD93D",
+  },
+];
+
+export default function LandingPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-background flex flex-col">
+      {/* Hero Section */}
+      <section className="flex-1 flex flex-col items-center justify-center px-4 py-12 text-center">
+        <h1 className="font-display font-bold text-h1 text-primary max-w-2xl">
+          {t("landing.title")}
+        </h1>
+
+        <p className="font-body text-body text-gray-600 mt-4 max-w-lg">
+          {t("landing.subtitle")}
+        </p>
+
+        <Button
+          variant="primary"
+          className="mt-8 text-lg px-10 py-4"
+          onClick={() => navigate("/criar")}
+        >
+          {t("landing.cta")}
+        </Button>
+      </section>
+
+      {/* Theme Preview Cards */}
+      <section className="px-4 pb-16">
+        <div className="max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-3 gap-4">
+          {themes.map((theme) => (
+            <ThemeCard
+              key={theme.labelKey}
+              emoji={theme.emoji}
+              label={t(theme.labelKey)}
+              color={theme.color}
+            />
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -3,7 +3,35 @@ import type { Config } from "tailwindcss";
 export default {
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: "#FFF8F0",
+        primary: "#6C5CE7",
+        secondary: "#FAB1A0",
+        accent: "#FFD93D",
+        success: "#00B894",
+        error: "#E17055",
+      },
+      fontFamily: {
+        display: ["Quicksand", "sans-serif"],
+        body: ["Nunito", "sans-serif"],
+      },
+      fontSize: {
+        h1: ["2.5rem", { lineHeight: "1.2" }],
+        h2: ["1.75rem", { lineHeight: "1.3" }],
+        h3: ["1.25rem", { lineHeight: "1.4" }],
+        body: ["1rem", { lineHeight: "1.5" }],
+        small: ["0.875rem", { lineHeight: "1.5" }],
+      },
+      borderRadius: {
+        DEFAULT: "0.75rem",
+        card: "1rem",
+        input: "0.5rem",
+      },
+      spacing: {
+        base: "0.5rem",
+      },
+    },
   },
   plugins: [],
 } satisfies Config;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./src/__tests__/setup.ts"],
+    css: true,
+  },
+});


### PR DESCRIPTION
## 📋 Descrição

Implementação da Landing Page (/) e tela de criação de música (/criar) para o KidsTune, aplicando os Design Tokens definidos no E1.

## 🚀 O que foi feito

### Design System aplicado
- **Cores:** background (#FFF8F0), primary (#6C5CE7), secondary (#FAB1A0), accent (#FFD93D), success (#00B894), error (#E17055)
- **Tipografia:** Quicksand (display) + Nunito (body) via Google Fonts
- **Border radius:** 0.75rem padrão, 1rem cards, 0.5rem inputs
- **Tailwind config** estendido com todas as tokens

### Rotas
- `/` — Landing page com hero, CTA e 3 cards de preview de tema
- `/criar` — Formulário completo de criação de música

### Componentes criados
- **Button** (variants: primary/secondary)
- **ThemeCard** (preview visual dos temas na landing)
- **Select** (wrap do native select com tokens)
- **LanguageFooter** (seletor de idioma EN-US / PT-BR)

### i18n
- 17 chaves em cada locale (en-US.json + pt-BR.json)
- Estrutura: `landing.*`, `criar.*`, `common.*`, `voice.*`, `style.*`, `themeOption.*`

### CreatePage (Formulário)
- Theme dropdown (6 opções + custom keyword input condicional)
- Kid name input (opcional)
- Voice dropdown (Feminina/Masculina/Instrumental)
- Style dropdown (Lullaby/Pop/Folk)
- Botão "Gerar música" com estado disabled durante submit
- Loading state com mensagem personalizada
- Stub do POST (`fetch('/api/generate')`) — mostra "Volte em breve" se 404

### Testes (Vitest + React Testing Library)
1. **LandingPage.test.tsx** — renderiza H1 + CTA + theme cards
2. **CreatePage.test.tsx** — render dos campos, custom keyword condicional, submit desabilita botão, 404 mostra mensagem amigável
3. **i18n.test.tsx** — switch en-US ↔ pt-BR muda o copy

## ✅ Critérios de aceitação
- [x] `npm run build --workspace frontend` completo sem erro
- [x] `npx vitest run` passa todos os testes
- [x] Visual aplica tokens do Design System (Tailwind config estendido)
- [x] 17+ chaves em CADA arquivo de locale
- [x] Mobile-friendly (responsive, 320px+)
- [x] Branch: `feat/e3-landing-ui`
- [x] Commit msg: `feat(ui): landing page + theme picker form`

## 🔒 Segurança
- Nenhuma chave/credencial incluída
- Nenhuma chamada real a Gemini
- Sem auth ou Firestore writes
