### PR TITLE
fix(ci): hoist secrets check into job-level env to satisfy Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,11 @@
 #     (the same as /home/user/.agent/firebase-service-account.json locally)
 #   - GEMINI_API_KEY: Google Gemini API key for lyrics generation
 #
-# If these secrets are not set, the workflow will fail gracefully with a warning.
+# If these secrets are not set, the deploy step is skipped and a warning is
+# emitted. We hoist the secret check into a job-level `env:` block (using a
+# GitHub Actions expression) and reference `env.HAS_FIREBASE_SA` from each
+# step `if:` — referencing `secrets.X` directly inside step `if:` is rejected
+# by Actions with "Unrecognized named-value: secrets".
 # =============================================================================
 
 name: Deploy to Firebase
@@ -22,6 +26,8 @@ jobs:
     name: Deploy Hosting + Functions
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      HAS_FIREBASE_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT != '' }}
 
     steps:
       - name: Checkout
@@ -45,7 +51,7 @@ jobs:
         run: npm run build -w functions
 
       - name: Deploy to Firebase
-        if: ${{ secrets.FIREBASE_SERVICE_ACCOUNT != '' }}
+        if: env.HAS_FIREBASE_SA == 'true'
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
@@ -56,7 +62,7 @@ jobs:
           FIREBASE_CLI_EXPERIMENTS: webframeworks
 
       - name: Warn about missing secrets
-        if: ${{ secrets.FIREBASE_SERVICE_ACCOUNT == '' }}
+        if: env.HAS_FIREBASE_SA != 'true'
         run: |
           echo "::warning::FIREBASE_SERVICE_ACCOUNT secret is not set."
           echo "::warning::Deploy skipped. To enable automatic deployment:"


### PR DESCRIPTION
## Why
Main was red on every push with:
```
Invalid workflow file: .github/workflows/deploy.yml#L1
(Line: 48, Col: 13): Unrecognized named-value: 'secrets'.
(Line: 59, Col: 13): Unrecognized named-value: 'secrets'.
```

GitHub Actions does not allow `secrets.X` directly inside step-level `if:` expressions. The accepted pattern is to materialize the boolean at the job level (where the secrets context is in scope) and reference that env from steps.

## What
- Added `env: { HAS_FIREBASE_SA: ${{ secrets.FIREBASE_SERVICE_ACCOUNT != '' }} }` at the job level.
- Step `Deploy to Firebase`: `if: env.HAS_FIREBASE_SA == 'true'`.
- Step `Warn about missing secrets`: `if: env.HAS_FIREBASE_SA != 'true'`.

## Why this couldn't be fixed by an autonomous DogInControl run
The task was triaged correctly to AUTONOMOUS by the Software Tech Lead, the AutoApproval rescued it from the risk gate, and the Tech Lead delegated to the Kata container — but the JVM-side execution pipeline silently fast-failed before reaching the harness. That's a separate platform-side defect outside the autonomy 3.0 plan's scope and will be diagnosed in a dedicated change. This direct-edit fallback is to unblock CI immediately.

## Test plan
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/deploy.yml"))'` — green.
- After merge, the Actions tab on `main` will no longer show `Invalid workflow file`. The `Warn about missing secrets` step will fire because the repo does not have `FIREBASE_SERVICE_ACCOUNT` set yet — that is expected; the deploy then runs as soon as the secret is added in repo Settings → Secrets → Actions.
