### PR TITLE
fix(functions): TS compile errors blocking Deploy step

### DIFF
--- a/functions/src/__tests__/generate.test.ts
+++ b/functions/src/__tests__/generate.test.ts
@@ -1,6 +1,6 @@
 import { generateHandler } from "../generate";
 import { freeQuotaHandler } from "../free-quota";
-import { Request, Response } from "firebase-functions/v2/https";
+import { Request, Response } from "express";
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -38,15 +38,14 @@ jest.mock("firebase-admin", () => {
 
   return {
     initializeApp: jest.fn(),
-    firestore: jest.fn().mockReturnValue({
-      collection: mockCollection,
-      runTransaction: mockRunTransaction,
-      Timestamp: mockTimestamp,
-    }),
-    // Static property access
-    firestore: {
-      Timestamp: mockTimestamp,
-    },
+    firestore: Object.assign(
+      jest.fn().mockReturnValue({
+        collection: mockCollection,
+        runTransaction: mockRunTransaction,
+        Timestamp: mockTimestamp,
+      }),
+      { Timestamp: mockTimestamp },
+    ),
   };
 });
 

--- a/functions/src/checkout.ts
+++ b/functions/src/checkout.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "firebase-functions/v2/https";
+import { Request, Response } from "express";
 import * as crypto from "crypto";
 import { PRICING, isValidPack } from "./pricing";
 

--- a/functions/src/free-quota.ts
+++ b/functions/src/free-quota.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "firebase-functions/v2/https";
+import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import * as crypto from "crypto";
 

--- a/functions/src/generate.ts
+++ b/functions/src/generate.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "firebase-functions/v2/https";
+import { Request, Response } from "express";
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 // ---------------------------------------------------------------------------
@@ -241,7 +241,7 @@ export async function generateHandler(req: Request, res: Response): Promise<void
     }
 
     // Build prompt
-    const prompt = buildPrompt({ theme, kidName, voice, style, locale });
+    const prompt = buildPrompt({ theme, kidName: kidName ?? undefined, voice, style, locale });
 
     // Get API key from environment (injected by Firebase Secrets at runtime)
     const apiKey = process.env.GEMINI_API_KEY;

--- a/functions/src/health.ts
+++ b/functions/src/health.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "firebase-functions/v2/https";
+import { Request, Response } from "express";
 
 export function healthHandler(_req: Request, res: Response): void {
   res.json({

--- a/functions/src/webhook.ts
+++ b/functions/src/webhook.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "firebase-functions/v2/https";
+import { Request, Response } from "express";
 import * as admin from "firebase-admin";
 import { addCredits, ensureUserDoc } from "./firestore-init";
 


### PR DESCRIPTION
Fix the 6 TS compile errors in functions/ that block the Deploy run after PRs #13 + #14 unblocked the workflow YAML and the lockfile.

## What
- Repoint Request/Response imports from firebase-functions/v2/https to express.
- Coerce kidName from `string | null` (sanitizeKidName) to `string | undefined` for buildPrompt with `?? undefined`.
- Merge the duplicate `firestore` mock property in generate.test.ts into a single Object.assign.

## Test plan
- `cd functions && npm run build` — green.
- After merge, the Deploy run on main reaches `Deploy to Firebase` (still skips until FIREBASE_SERVICE_ACCOUNT is set).

Refs #7.